### PR TITLE
Adding Error Message Grouping Feature using Levenshtein Distance instead of regexes

### DIFF
--- a/server-config.yml
+++ b/server-config.yml
@@ -11,7 +11,3 @@ mongoUri: "mongodb://${MONGO_HOST:-localhost}/${MONGO-DB:-zucchini}?connectTimeo
 
 logging:
   level: INFO
-
-errorOutputCodesPatterns:
-     NPE: NullPointerException
-     IllegalArgument: IllegalArgumentException

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/BackendConfiguration.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/BackendConfiguration.java
@@ -5,8 +5,6 @@ import io.dropwizard.metrics.MetricsFactory;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.util.HashMap;
-import java.util.Map;
 
 public class BackendConfiguration extends Configuration {
 
@@ -15,8 +13,6 @@ public class BackendConfiguration extends Configuration {
 
     @Valid
     private final MetricsFactory metrics = new MetricsFactory();
-
-    private Map<String, String> errorOutputCodesPatterns = new HashMap<>();
 
     public String getMongoUri() {
         return mongoUri;
@@ -28,10 +24,6 @@ public class BackendConfiguration extends Configuration {
 
     public MetricsFactory getMetrics() {
         return metrics;
-    }
-
-    public Map<String, String> getErrorOutputCodesPatterns() {
-        return errorOutputCodesPatterns;
     }
 
 }

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/reportconverter/converter/ReportScenarioConverter.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/reportconverter/converter/ReportScenarioConverter.java
@@ -3,7 +3,6 @@ package io.zucchiniui.backend.reportconverter.converter;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
-import io.zucchiniui.backend.BackendConfiguration;
 import io.zucchiniui.backend.feature.domain.Feature;
 import io.zucchiniui.backend.reportconverter.report.ReportAroundAction;
 import io.zucchiniui.backend.reportconverter.report.ReportAttachment;
@@ -24,26 +23,15 @@ import io.zucchiniui.backend.shared.domain.BasicInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Component
 class ReportScenarioConverter {
 
     private static final Joiner LINE_JOINER = Joiner.on('\n');
-
-    private final Map<Pattern, String> errorOutputCodePatterns = new HashMap<>();
-
-    public ReportScenarioConverter(BackendConfiguration configuration) {
-        configuration.getErrorOutputCodesPatterns().forEach((key, value) -> {
-            errorOutputCodePatterns.put(Pattern.compile(key, Pattern.MULTILINE), value);
-        });
-    }
 
     public ScenarioBuilder createScenarioBuilder(final Feature parentFeature, final ReportScenario reportScenario) {
 
@@ -71,7 +59,6 @@ class ReportScenarioConverter {
 
         for (final ReportStep reportStep : reportScenario.getSteps()) {
             scenarioBuilder.addStep(b -> buildStep(reportStep, b));
-            handleErrorOutputCodes(scenarioBuilder, reportStep.getResult().getErrorMessage());
         }
 
         for (final ReportAroundAction reportAroundAction : reportScenario.getBeforeActions()) {
@@ -134,16 +121,6 @@ class ReportScenarioConverter {
             .withOutput(output)
             .withTable(table)
             .withAttachments(attachments);
-    }
-
-    private void handleErrorOutputCodes(ScenarioBuilder scenarioBuilder, String errorMessage) {
-        if (!Strings.isNullOrEmpty(errorMessage)) {
-            final List<String> matchingErrorCodes = errorOutputCodePatterns.entrySet().stream()
-                .filter(p -> p.getKey().matcher(errorMessage).find())
-                .map(Map.Entry::getValue)
-                .collect(Collectors.toList());
-            scenarioBuilder.withErrorOutputCodes(matchingErrorCodes);
-        }
     }
 
     private static void buildAroundAction(final ReportAroundAction reportAroundAction, final AroundActionBuilder aroundActionBuilder) {

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/dao/ScenarioQueryImpl.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/dao/ScenarioQueryImpl.java
@@ -2,11 +2,10 @@ package io.zucchiniui.backend.scenario.dao;
 
 import io.zucchiniui.backend.scenario.domain.Scenario;
 import io.zucchiniui.backend.scenario.domain.ScenarioQuery;
+import io.zucchiniui.backend.scenario.domain.ScenarioStatus;
 import io.zucchiniui.backend.shared.domain.TagSelection;
 import io.zucchiniui.backend.support.ddd.morphia.BaseMorphiaQuery;
 import org.mongodb.morphia.query.Query;
-
-import java.util.List;
 
 class ScenarioQueryImpl extends BaseMorphiaQuery<Scenario> implements ScenarioQuery {
 
@@ -58,8 +57,8 @@ class ScenarioQueryImpl extends BaseMorphiaQuery<Scenario> implements ScenarioQu
     }
 
     @Override
-    public ScenarioQuery withErrorOutputCodes(List<String> errorOutputCodes) {
-        configureQuery(q -> q.field("errorOutputCodes").hasAnyOf(errorOutputCodes));
+    public ScenarioQuery havingErrorMessage() {
+        configureQuery(q -> q.field("status").equal(ScenarioStatus.FAILED).field("steps.errorMessage").exists());
         return this;
     }
 

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/ErrorMessageGroupingUtils.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/ErrorMessageGroupingUtils.java
@@ -1,0 +1,104 @@
+package io.zucchiniui.backend.scenario.domain;
+
+import io.zucchiniui.backend.scenario.views.ScenarioListItemView;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
+
+/**
+ * Utility class for regrouping errorMessages
+ */
+public final class ErrorMessageGroupingUtils {
+
+    // Number of characters to process for computing distances
+    public static final int NB_CHARACTERS_TO_PROCESS = 300;
+
+    // Maximum computed distance to consider 2 error messages as similar
+    private static final int MAX_DISTANCE_FOR_GROUPING = NB_CHARACTERS_TO_PROCESS / 10;
+
+    private ErrorMessageGroupingUtils() {
+        // Utils class should not be instantiated
+    }
+
+    /**
+     * Method indicating if a message can be considered similar, based on Levenshtein distance calculation with an allowed variation of 10%
+     *
+     * <b>Note:</b> Max tolerated distance is derived from the current scenario's error message
+     * The arbitrary "10" means we consider 10% change to be acceptable
+     *
+     * @param referenceText the reference text
+     * @param targetText the target text for the comparison
+     * @return true if the can be considered similar else false
+     */
+    public static boolean isSimilar(String referenceText, String targetText) {
+        int distance = StringUtils.getLevenshteinDistance(referenceText, targetText);
+
+        return distance < referenceText.length() / 10;
+    }
+
+    /**
+     * Utility method returning the error message in the scenario if present
+     * @param scenario the current scenario
+     * @return the error message contained in one of the steps (if any)
+     */
+    public static String extractErrorMessage(Scenario scenario) {
+        return scenario.getSteps()
+            .stream()
+            .filter(step -> StringUtils.isNotBlank(step.getErrorMessage()))
+            .findFirst()
+            .map(Step::getErrorMessage)
+            .orElse(StringUtils.EMPTY);
+    }
+
+    /**
+     * Method computing the distances between the error messages output
+     *
+     * @param scenarii All scenarii to consider during the computation
+     * @return Map containing the error message as key and all similar failedScenarioIds as value
+     */
+    public static Map<String, List<String>> computeDistance(List<ScenarioListItemView> scenarii) {
+        Map<String, List<String>> distances = new TreeMap<>();
+        scenarii.forEach(scenario -> {
+            String currentErrMsgText = StringUtils.left(scenario.getErrorMessage(), NB_CHARACTERS_TO_PROCESS);
+            String closestMatch = computeClosest(distances.keySet(), currentErrMsgText);
+            if (closestMatch != null) {
+                distances.get(closestMatch).add(scenario.getId());
+            } else {
+                List<String> noMatch = new ArrayList<>();
+                noMatch.add(scenario.getId());
+                distances.put(currentErrMsgText, noMatch);
+            }
+        });
+        return distances;
+    }
+
+    /**
+     * Method computing the closest existing errorMessage if it exists
+     *
+     * @param existingMatches already computed error message matches
+     * @param targetText      the text to check against the existing matches
+     * @return the closest key satisfying the MAX_DISTANCE_FOR_GROUPING, or null if none was found
+     */
+    private static String computeClosest(Set<String> existingMatches, String targetText) {
+
+        int closestDistance = Integer.MAX_VALUE;
+        String closestExistingMatchKey = null;
+
+        // FIXME Optimize processing time by avoiding unnecessary calls to the greedy LevenshteinDistance
+        for (String current : existingMatches) {
+
+                int distance = StringUtils.getLevenshteinDistance(current, targetText);
+                if (distance == 0) {
+                    // Exact match
+                    closestExistingMatchKey = current;
+                    break;
+                } else if (distance < MAX_DISTANCE_FOR_GROUPING && distance < closestDistance) {
+                    // Current existingMatchKey is closer to targetText
+                    closestDistance = distance;
+                    closestExistingMatchKey = current;
+                }
+
+        }
+        return closestExistingMatchKey;
+    }
+}

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/Scenario.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/Scenario.java
@@ -46,8 +46,6 @@ public class Scenario extends BaseEntity<String> {
 
     private boolean reviewed;
 
-    private List<String> errorOutputCodes = new ArrayList<>();
-
     private List<Step> steps = new ArrayList<>();
 
     private List<AroundAction> beforeActions = new ArrayList<>();
@@ -84,8 +82,6 @@ public class Scenario extends BaseEntity<String> {
 
         allTags = new HashSet<>(tags);
         allTags.addAll(builder.getExtraTags());
-
-        errorOutputCodes = builder.getErrorOutputCodes();
 
 
         if (builder.getBackgroundBuilder() != null) {
@@ -125,8 +121,6 @@ public class Scenario extends BaseEntity<String> {
         language = other.language;
         tags = new HashSet<>(other.tags);
         allTags = new HashSet<>(other.allTags);
-        errorOutputCodes = new ArrayList<>(other.errorOutputCodes);
-
 
         if (other.background == null) {
             background = null;
@@ -323,10 +317,6 @@ public class Scenario extends BaseEntity<String> {
 
     public ZonedDateTime getModifiedAt() {
         return modifiedAt;
-    }
-
-    public List<String> getErrorOutputCodes() {
-        return errorOutputCodes;
     }
 
     @Override

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/ScenarioBuilder.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/ScenarioBuilder.java
@@ -24,8 +24,6 @@ public class ScenarioBuilder {
 
     private BackgroundBuilder backgroundBuilder;
 
-    private List<String> errorOutputCodes = new ArrayList<>();
-
     private BasicInfo info;
 
     private String comment;
@@ -67,11 +65,6 @@ public class ScenarioBuilder {
 
     public ScenarioBuilder withExtraTags(final Set<String> extraTags) {
         this.extraTags = extraTags;
-        return this;
-    }
-
-    public ScenarioBuilder withErrorOutputCodes(final List<String> errorOutputCodes) {
-        this.errorOutputCodes = errorOutputCodes;
         return this;
     }
 
@@ -135,10 +128,6 @@ public class ScenarioBuilder {
 
     public Set<String> getExtraTags() {
         return extraTags;
-    }
-
-    public List<String> getErrorOutputCodes() {
-        return errorOutputCodes;
     }
 
     protected BackgroundBuilder getBackgroundBuilder() {

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/ScenarioQuery.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/domain/ScenarioQuery.java
@@ -2,8 +2,6 @@ package io.zucchiniui.backend.scenario.domain;
 
 import io.zucchiniui.backend.shared.domain.TagSelection;
 
-import java.util.List;
-
 public interface ScenarioQuery {
 
     ScenarioQuery withFeatureId(String featureId);
@@ -18,6 +16,5 @@ public interface ScenarioQuery {
 
     ScenarioQuery withSelectedTags(TagSelection tagSelection);
 
-    ScenarioQuery withErrorOutputCodes(List<String> errorOutputCodes);
-
+    ScenarioQuery havingErrorMessage();
 }

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/rest/ScenarioResource.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/rest/ScenarioResource.java
@@ -88,7 +88,7 @@ public class ScenarioResource {
 
     @GET
     @Path("associatedFailures")
-    public Map<String, List<String>> getAllAssociatedFailures(@BeanParam final GetScenariiRequestParams requestParams) {
+    public Map<String, List<ScenarioListItemView>> getAllAssociatedFailures(@BeanParam final GetScenariiRequestParams requestParams) {
         Consumer<ScenarioQuery> query = q -> {
             if (!Strings.isNullOrEmpty(requestParams.getTestRunId())) {
                 q.withTestRunId(requestParams.getTestRunId());

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/views/ScenarioListItemView.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/views/ScenarioListItemView.java
@@ -17,6 +17,8 @@ public class ScenarioListItemView {
 
     private String featureId;
 
+    private String errorMessage;
+
     public String getId() {
         return id;
     }
@@ -63,6 +65,14 @@ public class ScenarioListItemView {
 
     public void setFeatureId(final String featureId) {
         this.featureId = featureId;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
     }
 
 }

--- a/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/views/ScenarioViewAccess.java
+++ b/zucchini-ui-backend/src/main/java/io/zucchiniui/backend/scenario/views/ScenarioViewAccess.java
@@ -66,8 +66,8 @@ public class ScenarioViewAccess {
         return MorphiaUtils.streamQuery(query).collect(Collectors.toMap(Scenario::getScenarioKey, scenarioToListItemViewMapper::map));
     }
 
-    public List<ScenarioListItemView> getFailedScenarii(final String testRunId) {
-        final Query<Scenario> query = scenarioDAO.prepareTypedQuery(q -> q.withTestRunId(testRunId).havingErrorMessage());
+    public List<ScenarioListItemView> getFailedScenarii(final Consumer<ScenarioQuery> preparator) {
+        final Query<Scenario> query = scenarioDAO.prepareTypedQuery(preparator);
         return MorphiaUtils.streamQuery(query)
             .map(scenario -> {
                 ScenarioListItemView listItem = scenarioToListItemViewMapper.map(scenario);


### PR DESCRIPTION
Hello @pgentile,

I've modified the error message grouping feature to avoid unnecessary configs using regexes.
The code is now able to regroup similar error messages by relying on the Levenshtein distance calclutation
